### PR TITLE
UI atoms components - Input, Textarea, Checkbox

### DIFF
--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -1,12 +1,7 @@
+import React from 'react';
 import { ButtonHTMLAttributes, PropsWithChildren, forwardRef } from 'react';
 import { cva } from 'class-variance-authority';
-import { ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-import React from 'react';
-
-export const cn = (...inputs: ClassValue[]) => {
-  return twMerge(clsx(inputs));
-};
+import { cn } from '../../../utils';
 
 type IconProps = {
   icon: React.ReactNode;

--- a/src/components/atoms/Checkbox/Checkbox.stories.tsx
+++ b/src/components/atoms/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Checkbox from './Checkbox';
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'weview/Atoms/Checkbox',
+  component: Checkbox,
+  tags: ['autodocs'],
+  args: {
+    children: 'Example',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Checkbox>;
+
+export const Default: Story = {};

--- a/src/components/atoms/Checkbox/Checkbox.test.tsx
+++ b/src/components/atoms/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@/tests/test-utils';
+
+import Checkbox from './Checkbox';
+
+describe('Checkbox 컴포넌트 테스트', () => {
+  test('Checkbox 컴포넌트가 렌더링된다.', () => {
+    render(<Checkbox>체크</Checkbox>);
+    expect(screen.getByLabelText('체크')).toBeInTheDocument();
+  });
+});

--- a/src/components/atoms/Checkbox/Checkbox.tsx
+++ b/src/components/atoms/Checkbox/Checkbox.tsx
@@ -1,0 +1,31 @@
+import { InputHTMLAttributes, forwardRef } from 'react';
+import { cn } from '../../../utils';
+
+export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
+  /**
+   * 체크박스의 내용을 설정합니다.
+   */
+  children?: React.ReactNode;
+}
+
+const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+  { children, className, ...props },
+  forwardRef,
+) {
+  return (
+    <label className="flex  gap-3">
+      <input
+        ref={forwardRef}
+        type="checkbox"
+        className={cn(
+          `flex items-center justify-center border-none text-current`,
+          className,
+        )}
+        {...props}
+      />
+      <span>{children}</span>
+    </label>
+  );
+});
+
+export default Checkbox;

--- a/src/components/atoms/Checkbox/index.ts
+++ b/src/components/atoms/Checkbox/index.ts
@@ -1,0 +1,1 @@
+export * from './Checkbox';

--- a/src/components/atoms/Input/Input.stories.tsx
+++ b/src/components/atoms/Input/Input.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Input from './Input';
+
+const meta: Meta<typeof Input> = {
+  title: 'weview/Atoms/Input',
+  component: Input,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {
+    placeholder: 'outlined',
+    variant: 'outlined',
+  },
+};
+
+export const Borderless: Story = {
+  args: {
+    variant: 'borderless',
+    placeholder: 'borderless',
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    variant: 'filled',
+    placeholder: 'filled',
+  },
+};
+
+export const Label: Story = {
+  args: {
+    label: 'label',
+    placeholder: 'label',
+  },
+};

--- a/src/components/atoms/Input/Input.test.tsx
+++ b/src/components/atoms/Input/Input.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from '@/tests/test-utils';
+import Input from './Input';
+
+describe('Input 컴포넌트 테스트 및 placeholder 체크', () => {
+  test('Input 컴포넌트가 렌더링된다.', () => {
+    render(<Input placeholder="아이디를 입력해주세요." />);
+    expect(
+      screen.getByPlaceholderText('아이디를 입력해주세요.'),
+    ).toBeInTheDocument();
+  });
+  test('disabled된 Input 컴포넌트가 렌더링된다.', () => {
+    render(<Input placeholder="아이디를 입력해주세요." disabled />);
+    expect(
+      screen.getByPlaceholderText('아이디를 입력해주세요.'),
+    ).toHaveAttribute('disabled');
+  });
+
+  test('Input 컴포넌트의 입력에 따라 value가 변한다.', () => {
+    render(<Input placeholder="아이디를 입력해주세요." />);
+    const input = screen.getByPlaceholderText('아이디를 입력해주세요.');
+    fireEvent.change(input, { target: { value: 'test' } });
+    expect(input).toHaveValue('test');
+  });
+
+  test('Input 컴포넌트의 label이 렌더링된다.', () => {
+    render(<Input placeholder="아이디를 입력해주세요." label="아이디" />);
+    expect(screen.getByText('아이디')).toBeInTheDocument();
+  });
+});

--- a/src/components/atoms/Input/Input.tsx
+++ b/src/components/atoms/Input/Input.tsx
@@ -1,0 +1,46 @@
+import { cva } from 'class-variance-authority';
+import { InputHTMLAttributes } from 'react';
+import { cn } from '../../../utils';
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  /**
+   * label을 함께 입력할 수 있습니다.
+   */
+  label?: string;
+  /**
+   * Input의 스타일 타입을 지정합니다.
+   */
+  variant?: 'outlined' | 'borderless' | 'filled';
+}
+const InputVariants = cva(
+  `flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50`,
+  {
+    variants: {
+      variant: {
+        outlined: ['border-input', 'bg-background', 'px-3', 'py-2', 'text-sm'],
+        borderless: ['border-0', 'bg-transparent', 'text-sm', 'font-medium'],
+        filled: ['border-0', 'bg-gray-300', 'text-sm'],
+      },
+    },
+  },
+);
+
+const Input = ({
+  label,
+  variant = 'outlined',
+  className,
+  ...props
+}: InputProps) => {
+  return (
+    <div className="flex items-center gap-3">
+      {label && <label htmlFor={label}>{label}</label>}
+      <input
+        aria-label="input"
+        className={cn(InputVariants({ variant, className }))}
+        {...props}
+      />
+    </div>
+  );
+};
+
+export default Input;

--- a/src/components/atoms/Input/index.ts
+++ b/src/components/atoms/Input/index.ts
@@ -1,0 +1,1 @@
+export * from './Input';

--- a/src/components/atoms/Textarea/Textarea.stories.tsx
+++ b/src/components/atoms/Textarea/Textarea.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Textarea from './Textarea';
+
+const meta: Meta<typeof Textarea> = {
+  title: 'weview/Atoms/Textarea',
+  component: Textarea,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Textarea>;
+
+export const Default: Story = {
+  args: {
+    placeholder: '텍스트를 입력해주세요',
+  },
+};

--- a/src/components/atoms/Textarea/Textarea.test.tsx
+++ b/src/components/atoms/Textarea/Textarea.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from '@/tests/test-utils';
+
+import Textarea from './Textarea';
+
+describe('Textarea 컴포넌트 테스트 및 placeholder 체크', () => {
+  test('Textarea 컴포넌트가 렌더링된다.', () => {
+    render(<Textarea placeholder="텍스트를 입력해주세요." />);
+    expect(
+      screen.getByPlaceholderText('텍스트를 입력해주세요.'),
+    ).toBeInTheDocument();
+  });
+  test('disabled된 Textarea 컴포넌트가 렌더링된다.', () => {
+    render(<Textarea placeholder="텍스트를 입력해주세요." disabled />);
+    expect(
+      screen.getByPlaceholderText('텍스트를 입력해주세요.'),
+    ).toHaveAttribute('disabled');
+  });
+
+  test('Textarea 컴포넌트의 입력에 따라 value가 변한다.', () => {
+    render(<Textarea placeholder="텍스트를 입력해주세요." />);
+    const input = screen.getByPlaceholderText('텍스트를 입력해주세요.');
+    fireEvent.change(input, { target: { value: 'test' } });
+    expect(input).toHaveValue('test');
+  });
+
+  test('Textarea 컴포넌트의 label이 렌더링된다.', () => {
+    render(<Textarea placeholder="텍스트를 입력해주세요." label="텍스트" />);
+    expect(screen.getByText('텍스트')).toBeInTheDocument();
+  });
+});

--- a/src/components/atoms/Textarea/Textarea.tsx
+++ b/src/components/atoms/Textarea/Textarea.tsx
@@ -1,0 +1,27 @@
+import { cn } from '../../../utils';
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  /**
+   * label을 함께 입력할 수 있습니다.
+   */
+  label?: string;
+}
+
+const Textarea = ({ label, className, ...props }: TextareaProps) => {
+  return (
+    <>
+      {label && <label htmlFor={label}>{label}</label>}
+      <textarea
+        className={cn(
+          `          "flex border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring disabled:opacity-50", min-h-[80px] w-full rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed
+        `,
+          className,
+        )}
+        {...props}
+      />
+    </>
+  );
+};
+
+export default Textarea;

--- a/src/components/atoms/Textarea/index.ts
+++ b/src/components/atoms/Textarea/index.ts
@@ -1,0 +1,1 @@
+export * from './Textarea';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,6 @@
+import clsx, { ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export const cn = (...inputs: ClassValue[]) => {
+  return twMerge(clsx(inputs));
+};


### PR DESCRIPTION
# Description
Input, Textarea, Checkbox 컴포넌트 구현

## Type of change
- New feature _ Input 
- New feature _ Textarea 
- New feature _ Checkbox 

# Checklist

- [x] 정해진 폴더구조, 컨벤션에 따라 작성
- [ ] 생각할 수 있는 모든 예외상황과 모든 경우의 수를 테스트
- [x] 이해하기 어려운 코드에 주석 작성
- [x] Push 전, 충분한 리팩토링
- [x] Rebase 후, 모든 동작들이 정상 작동 하는지 확인
- [x] 해당 PR과 충돌할 가능성이 있는 컴포넌트 및 사이드 이펙트 체크

## 문제 
- `import { cn } from '../../../utils';` 절대경로를 스토리북에서 제대로 읽지못하는 이슈가 있어 이부분은 상대경로로 입력해두었습니다
[스토리북 관련 이슈](https://github.com/storybookjs/storybook/issues/3916)인것 같아 webpack 설치 후 설정 변경했음에도 동일한 문제가 발생하여 webpack은 다시 제거하였습니다. 

## 고민
input, textarea, checkbox 모두 비제어컴포넌트로 구현했는데...
Form에서 사용될 것을 고민한다면 제어컴포넌트로 구현해야하는지? 단순히 입력을 받아 사용할 때에는 비제어컴포넌트로도 충분할것같은데 이부분이 고민이 되었습니다!

## 잡담
- atom이라 생각되었는데 구현 안한 부분은 `<Avatar/>`,`<Tag/>`, `<Typography/>` 이렇게 남았는데 다음단계로 넘어가서 필요할때 구현하는게 좋을 것 같단 생각이들었습니다..... 계속 정체 할수없기에...하하핫

- 테스트코드는 아직 너무 어려워요... 